### PR TITLE
fixed frameMargins bug on multiple displays

### DIFF
--- a/src/plugins/platforms/windows/qwindowswindow.cpp
+++ b/src/plugins/platforms/windows/qwindowswindow.cpp
@@ -2763,7 +2763,7 @@ void QWindowsWindow::setFullFrameMargins(const QMargins &newMargins)
 void QWindowsWindow::updateFullFrameMargins()
 {
     // QTBUG-82580: If a native menu is present, force a WM_NCCALCSIZE.
-    if (GetMenu(m_data.hwnd))
+    if (GetMenu(m_data.hwnd) || (m_data.flags & Qt::MSWindowsNoRedirectionBitmap))
         QWindowsContext::forceNcCalcSize(m_data.hwnd);
     else
         calculateFullFrameMargins();


### PR DESCRIPTION
Dodałem sprawdzanie flagi, żeby sforsować WM_NCCALCSIZE w tym miejscu,
do tej pory używał AdjustWindowRectExForDpi który zwracał zły top margin
przez co przy przejściu między monitorami psuły się frameMargins'y.
W src/plugins/platforms/windows/qwindowswindow.cpp:1517 jest kod który
poprawnie oblicza te marginesy(dlatego przy resize'ie się naprawiało)